### PR TITLE
Fixed bug when app crash, when there's no any marker on mobile map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.7.1]
+
+* Fixed bug when app crash, when there's no any marker on mobile map
+
 ## [3.7.0]
 
 * Changed onTap VoidCallback to onTap ValueChanged with marker ID as an argument

--- a/lib/src/mobile/google_map.state.dart
+++ b/lib/src/mobile/google_map.state.dart
@@ -4,16 +4,15 @@
 
 import 'dart:async';
 
-import 'package:flutter/widgets.dart';
-
 import 'package:flinq/flinq.dart';
-import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:flutter/widgets.dart';
 import 'package:google_directions_api/google_directions_api.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
 
-import 'utils.dart';
-import '../core/utils.dart' as utils;
 import '../core/google_map.dart' as gmap;
 import '../core/map_items.dart' as items;
+import '../core/utils.dart' as utils;
+import 'utils.dart';
 
 class GoogleMapState extends gmap.GoogleMapStateBase {
   final directionsService = DirectionsService();
@@ -201,11 +200,8 @@ class GoogleMapState extends gmap.GoogleMapStateBase {
     }());
 
     final request = DirectionsRequest(
-      origin: origin is GeoCoord
-          ? LatLng(origin.latitude, origin.longitude)
-          : origin,
-      destination:
-          destination is GeoCoord ? destination.toLatLng() : destination,
+      origin: origin is GeoCoord ? LatLng(origin.latitude, origin.longitude) : origin,
+      destination: destination is GeoCoord ? destination.toLatLng() : destination,
       travelMode: TravelMode.driving,
     );
     directionsService.route(
@@ -264,8 +260,7 @@ class GoogleMapState extends gmap.GoogleMapStateBase {
           final polylineId = PolylineId(key);
           final polyline = Polyline(
             polylineId: polylineId,
-            points: response?.routes?.firstOrNull?.overviewPath
-                    ?.mapList((_) => _.toLatLng()) ??
+            points: response?.routes?.firstOrNull?.overviewPath?.mapList((_) => _.toLatLng()) ??
                 [startLatLng?.toLatLng(), endLatLng?.toLatLng()],
             color: const Color(0xcc2196F3),
             startCap: Cap.roundCap,
@@ -364,10 +359,8 @@ class GoogleMapState extends gmap.GoogleMapStateBase {
         consumeTapEvents: onTap != null,
         onTap: onTap != null ? () => onTap(id) : null,
         strokeWidth: strokeWidth?.toInt() ?? 1,
-        strokeColor: (strokeColor ?? const Color(0x000000))
-            .withOpacity(strokeOpacity ?? 0.8),
-        fillColor: (fillColor ?? const Color(0x000000))
-            .withOpacity(fillOpacity ?? 0.35),
+        strokeColor: (strokeColor ?? const Color(0x000000)).withOpacity(strokeOpacity ?? 0.8),
+        fillColor: (fillColor ?? const Color(0x000000)).withOpacity(fillOpacity ?? 0.35),
       ),
     );
   }
@@ -417,8 +410,10 @@ class GoogleMapState extends gmap.GoogleMapStateBase {
   @override
   void initState() {
     super.initState();
-    for (var marker in widget.markers) {
-      addMarker(marker);
+    if (widget.markers != null) {
+      for (var marker in widget.markers) {
+        addMarker(marker);
+      }
     }
   }
 
@@ -433,8 +428,7 @@ class GoogleMapState extends gmap.GoogleMapStateBase {
               polygons: Set<Polygon>.of(_polygons.values),
               polylines: Set<Polyline>.of(_polylines.values),
               mapType: MapType.values[widget.mapType.index],
-              minMaxZoomPreference:
-                  MinMaxZoomPreference(widget.minZoom, widget.minZoom),
+              minMaxZoomPreference: MinMaxZoomPreference(widget.minZoom, widget.minZoom),
               initialCameraPosition: CameraPosition(
                 target: widget.initialPosition.toLatLng(),
                 zoom: widget.initialZoom,
@@ -454,14 +448,11 @@ class GoogleMapState extends gmap.GoogleMapStateBase {
               indoorViewEnabled: widget.mobilePreferences.indoorViewEnabled,
               mapToolbarEnabled: widget.mobilePreferences.mapToolbarEnabled,
               myLocationEnabled: widget.mobilePreferences.myLocationEnabled,
-              myLocationButtonEnabled:
-                  widget.mobilePreferences.myLocationButtonEnabled,
+              myLocationButtonEnabled: widget.mobilePreferences.myLocationButtonEnabled,
               tiltGesturesEnabled: widget.mobilePreferences.tiltGesturesEnabled,
               zoomGesturesEnabled: widget.mobilePreferences.zoomGesturesEnabled,
-              rotateGesturesEnabled:
-                  widget.mobilePreferences.rotateGesturesEnabled,
-              scrollGesturesEnabled:
-                  widget.mobilePreferences.scrollGesturesEnabled,
+              rotateGesturesEnabled: widget.mobilePreferences.rotateGesturesEnabled,
+              scrollGesturesEnabled: widget.mobilePreferences.scrollGesturesEnabled,
             ),
           ),
         ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_google_maps
-version: 3.7.0
+version: 3.7.1
 homepage: https://github.com/marchdev-tk/flutter_google_maps
 description: A Flutter plugin for integrating Google Maps in iOS, Android and Web applications. It is a wrapper of google_maps_flutter for Mobile and google_maps for Web.
 


### PR DESCRIPTION
## Description

Mobile app crash when there's no any markers. I did a change in mobile google_map_state where I'm checking if widget.markers != null

## Related Issues

https://github.com/marchdev-tk/flutter_google_maps/issues/26

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x ] I updated/added relevant documentation (doc comments with `///`).
- [ x] All existing and new tests are passing.
- [x ] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: *Replace with a link to your migration guide*

<!-- Links -->
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
