### PR TITLE
[fix] "TypeError: this.widget.markers is not iterable"

### DIFF
--- a/lib/src/core/google_map.dart
+++ b/lib/src/core/google_map.dart
@@ -24,7 +24,7 @@ class GoogleMap extends StatefulWidget {
     this.minZoom,
     this.maxZoom,
     this.mapStyle,
-    this.markers,
+    this.markers = const <Marker>{},
     this.onTap,
     this.onLongPress,
     this.interactive = true,


### PR DESCRIPTION
Added `const <Marker>{}` default value to `GoogleMap.markers`

## Description

I was getting the following error:
```
The following JSNoSuchMethodError was thrown during a scheduler callback:
TypeError: this.widget.markers is not iterable

When the exception was thrown, this was the stack:
packages/flutter_google_maps/src/web/google_map.state.dart 638:33  <fn>
packages/flutter/src/scheduler/binding.dart 1144:15                [_invokeFrameCallback]
packages/flutter/src/scheduler/binding.dart 1090:9                 handleDrawFrame
packages/flutter/src/scheduler/binding.dart 998:5                  [_handleDrawFrame]
lib/_engine/engine/platform_dispatcher.dart 896:13                 invoke
lib/_engine/engine/platform_dispatcher.dart 145:5                  invokeOnDrawFrame
lib/_engine/engine.dart 257:45                                     <fn>
```
so this PR fixes it.

## Related Issues

-

## Tests

-

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them?

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
